### PR TITLE
Fixed config to include mirroring on Eagle stab

### DIFF
--- a/GameData/ModeratelyPlaneRelated/Parts/Aero/HighPerformanceCtrl/TCA_HP_Control03.cfg
+++ b/GameData/ModeratelyPlaneRelated/Parts/Aero/HighPerformanceCtrl/TCA_HP_Control03.cfg
@@ -57,6 +57,13 @@ PART
     MODULE
     {
         name = SAETargetedTransformMirror
+        mirrorTarget = SAE_HP_Ctrl_03_Eagle
+        mirrorScaleAxis = 0,0,1
+    }
+    
+    MODULE
+    {
+        name = SAETargetedTransformMirror
         mirrorTarget = SAE_HP_Ctrl_03_Aquila
         mirrorScaleAxis = 0,0,1
     }


### PR DESCRIPTION
Config was missing mirroring on Eagle stabilitor variant.